### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cedric-jimenez/erp/security/code-scanning/3](https://github.com/cedric-jimenez/erp/security/code-scanning/3)

To fix the problem, we need to add a `permissions` block to the workflow, specifying only the minimum necessary privileges for its operations. Since the workflow performs only reading operations on the repository (checking out code, running tests), the minimal sufficient permission is `contents: read`. This `permissions` block can be added at the root of the workflow file, near the top under the `name:` and before the `on:` section. No other changes are needed, and functionality will be unaffected. No imports or method changes are involved; this is a configuration change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
